### PR TITLE
Minimizes argument parsing boilerplate code

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -22,6 +22,8 @@ pub fn build(b: *std.build.Builder) !void {
 
     var iterator = src.iterate();
     while (try iterator.next()) |file| {
+        // std.debug.print("name = {s}", .{file.name});
+        if (std.mem.indexOf(u8, file.name, ".") == null) continue;
         const name = std.mem.tokenize(file.name, ".").next().?;
 
         var alloc_join = std.heap.GeneralPurposeAllocator(.{}){};

--- a/src/cat.zig
+++ b/src/cat.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
-const args = @import("args");
 const build_options = @import("build_options");
+const parse_helper = @import("helpers/parse.zig");
 const io = std.io;
 const heap = std.heap;
 const math = std.math;
@@ -8,25 +8,15 @@ const stdin = io.getStdIn().reader();
 const stdout = io.getStdOut().writer();
 
 pub fn main() !void {
-    var errorCollectorGPA = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = errorCollectorGPA.deinit();
-    var collection = args.ErrorCollection.init(&errorCollectorGPA.allocator);
-    defer _ = collection.deinit();
-
-    var argsAllocator = std.heap.page_allocator;
-    const ops = args.parseForCurrentProcess(struct {
+    const ops = try parse_helper.parseArgs(struct {
         help: bool = false,
         version: bool = false,
 
         pub const shorthands = .{
             .h = "help",
         };
-    }, argsAllocator, args.ErrorHandling{ .collect = &collection }) catch {
-        for (collection.errors()) |err| {
-            try stdout.print("{}\n", .{err});
-        }
-        return;
-    };
+    });
+
     defer ops.deinit();
 
     if (ops.options.version) {

--- a/src/echo.zig
+++ b/src/echo.zig
@@ -1,29 +1,19 @@
 const std = @import("std");
-const args = @import("args");
 const build_options = @import("build_options");
+const parse_helper = @import("helpers/parse.zig");
 const io = std.io;
 const os = std.os;
 const stdout = io.getStdOut().writer();
 
 pub fn main() !void {
-    var errorCollectorGPA = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = errorCollectorGPA.deinit();
-    var collection = args.ErrorCollection.init(&errorCollectorGPA.allocator);
-    defer _ = collection.deinit();
-
-    var argsAllocator = std.heap.page_allocator;
-    const ops = args.parseForCurrentProcess(struct {
+    const ops = try parse_helper.parseArgs(struct {
         help: bool = false,
         newline: bool = false,
         version: bool = false,
 
         pub const shorthands = .{ .h = "help", .v = "version", .n = "newline" };
-    }, argsAllocator, args.ErrorHandling{ .collect = &collection }) catch {
-        for (collection.errors()) |err| {
-            try stdout.print("{}\n", .{err});
-        }
-        return;
-    };
+    });
+
     defer ops.deinit();
 
     if (ops.options.version) {

--- a/src/helpers/parse.zig
+++ b/src/helpers/parse.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+const args = @import("args");
+
+pub fn parseArgs(comptime Spec: type) !args.ParseArgsResult(Spec) {
+    var errorCollectorGPA = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = errorCollectorGPA.deinit();
+
+    var collection = args.ErrorCollection.init(&errorCollectorGPA.allocator);
+    defer _ = collection.deinit();
+    
+    const ops = args.parseForCurrentProcess(Spec, std.heap.page_allocator, args.ErrorHandling{ .collect = &collection }) catch {
+        for (collection.errors()) |err| {
+            try std.io.getStdOut().writer().print("{}\n", .{err});
+        }
+        std.os.exit(1);
+    };
+    return ops;
+}


### PR DESCRIPTION
This moves the parsing code to its own function and modifies the
buildscript to ignore filenames who doesn't contain any "." (consider
them as folders).

Fixes #5 